### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,6 @@
 name: Build and Test
+permissions:
+  contents: read
 on: [ push ]
 jobs:
   build:


### PR DESCRIPTION
Potential fix for [https://github.com/forketyfork/coding-problems-kotlin/security/code-scanning/1](https://github.com/forketyfork/coding-problems-kotlin/security/code-scanning/1)

To fix this issue, we need to explicitly limit the permissions granted to the workflow by adding a `permissions` block. Since the steps shown (checkout, setup Java, setup Gradle, and run build) do not require write access to the repository, the minimal required permission is typically `contents: read`. This can be set either at the root of the workflow YAML (recommended, as it applies to all jobs unless overridden), or at the job level. In this case, it's best to add it at the root, right after the workflow `name:` or `on:` key, in `.github/workflows/build.yml`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
